### PR TITLE
FE-28 : increase SSL renew before window to avoid Kuma noise [semver:patch]

### DIFF
--- a/custom-resource/certificate/targetdomain-region-demos.yaml.tpl
+++ b/custom-resource/certificate/targetdomain-region-demos.yaml.tpl
@@ -6,7 +6,7 @@ metadata:
 spec:
   secretName: ${target_domain_stringified}-demos
   duration: 2160h0m0s # 90d
-  renewBefore: 360h0m0s # 15d
+  renewBefore: 720h0m0s # 30d
   isCA: null #false
   privateKey:
     algorithm: RSA

--- a/custom-resource/certificate/targetdomain-region-dev.yaml.tpl
+++ b/custom-resource/certificate/targetdomain-region-dev.yaml.tpl
@@ -6,7 +6,7 @@ metadata:
 spec:
   secretName: ${target_domain_stringified}-2
   duration: 2160h0m0s # 90d
-  renewBefore: 360h0m0s # 15d
+  renewBefore: 720h0m0s # 15d
   isCA: null #false
   privateKey:
     algorithm: RSA

--- a/custom-resource/certificate/targetdomain-region-drdemo.yaml.tpl
+++ b/custom-resource/certificate/targetdomain-region-drdemo.yaml.tpl
@@ -6,7 +6,7 @@ metadata:
 spec:
   secretName: ${target_domain_stringified}-drdemo
   duration: 2160h0m0s # 90d
-  renewBefore: 360h0m0s # 15d
+  renewBefore: 720h0m0s # 15d
   isCA: null #false
   privateKey:
     algorithm: RSA

--- a/custom-resource/certificate/targetdomain-region-fieldguide.yaml.tpl
+++ b/custom-resource/certificate/targetdomain-region-fieldguide.yaml.tpl
@@ -6,7 +6,7 @@ metadata:
 spec:
   secretName: fieldguide-${target_domain_stringified}
   duration: 2160h0m0s # 90d
-  renewBefore: 360h0m0s # 15d
+  renewBefore: 720h0m0s # 15d
   isCA: null #false
   privateKey:
     algorithm: RSA

--- a/custom-resource/certificate/targetdomain-region-nexus.yaml.tpl
+++ b/custom-resource/certificate/targetdomain-region-nexus.yaml.tpl
@@ -6,7 +6,7 @@ metadata:
 spec:
   secretName: nexus-${target_domain_stringified}
   duration: 2160h0m0s # 90d
-  renewBefore: 360h0m0s # 15d
+  renewBefore: 720h0m0s # 15d
   isCA: null #false
   privateKey:
     algorithm: RSA

--- a/custom-resource/certificate/targetdomain-region-server4.yaml.tpl
+++ b/custom-resource/certificate/targetdomain-region-server4.yaml.tpl
@@ -6,7 +6,7 @@ metadata:
 spec:
   secretName: server4-${target_domain_stringified}
   duration: 2160h0m0s # 90d
-  renewBefore: 360h0m0s # 15d
+  renewBefore: 720h0m0s # 15d
   isCA: null #false
   privateKey:
     algorithm: RSA

--- a/custom-resource/certificate/targetdomain-region.yaml.tpl
+++ b/custom-resource/certificate/targetdomain-region.yaml.tpl
@@ -6,7 +6,7 @@ metadata:
 spec:
   secretName: ${target_domain_stringified}
   duration: 2160h0m0s # 90d
-  renewBefore: 360h0m0s # 15d
+  renewBefore: 720h0m0s # 15d
   isCA: null #false
   privateKey:
     algorithm: RSA


### PR DESCRIPTION
Currently Kuma monitor is hard coded to use 30 day window for concern on SSL certs, and we renew 15 days out.

THis change keeps 90d window but renews before 30 days.