### PR TITLE
rev kilai chart to latest [semver:major]

### DIFF
--- a/helm-values/istio-base.yaml
+++ b/helm-values/istio-base.yaml
@@ -1,4 +1,6 @@
-defaults:
+# "_internal_defaults_do_not_set" is a workaround for Helm limitations. Users should NOT set "._internal_defaults_do_not_set" explicitly, but rather directly set the fields internally.
+# For instance, instead of `--set _internal_defaults_do_not_set.foo=bar``, just set `--set foo=bar`.
+_internal_defaults_do_not_set:
   global:
 
     # ImagePullSecrets for control plane ServiceAccount, list of secrets in the same namespace
@@ -8,23 +10,18 @@ defaults:
 
     # Used to locate istiod.
     istioNamespace: istio-system
-
-    externalIstiod: false
-    remotePilotAddress: ""
-
-    # Platform where Istio is deployed. Possible values are: "openshift", "gcp".
-    # An empty value means it is a vanilla Kubernetes distribution, therefore no special
-    # treatment will be considered.
-    platform: ""
-
-    # Setup how istiod Service is configured. See https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services
-    # This is intended only for use with external istiod.
-    ipFamilyPolicy: ""
-    ipFamilies: []
-
   base:
-    # Used for helm2 to add the CRDs to templates.
-    enableCRDTemplates: false
+    # A list of CRDs to exclude. Requires `enableCRDTemplates` to be true.
+    # Example: `excludedCRDs: ["envoyfilters.networking.istio.io"]`.
+    # Note: when installing with `istioctl`, `enableIstioConfigCRDs=false` must also be set.
+    excludedCRDs: []
+    # Helm (as of V3) does not support upgrading CRDs, because it is not universally
+    # safe for them to support this.
+    # Istio as a project enforces certain backwards-compat guarantees that allow us
+    # to safely upgrade CRDs in spite of this, so we default to self-managing CRDs
+    # as standard K8S resources in Helm, and disable Helm's CRD management. See also:
+    # https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#method-2-separate-charts
+    enableCRDTemplates: true
 
     # Validation webhook configuration url
     # For example: https://$remotePilotAddress:15017/validate

--- a/helm-values/istio-ingress.yaml
+++ b/helm-values/istio-ingress.yaml
@@ -1,4 +1,6 @@
-defaults:
+# "_internal_defaults_do_not_set" is a workaround for Helm limitations. Users should NOT set "._internal_defaults_do_not_set" explicitly, but rather directly set the fields internally.
+# For instance, instead of `--set _internal_defaults_do_not_set.foo=bar``, just set `--set foo=bar`.
+_internal_defaults_do_not_set:
   # Name allows overriding the release name. Generally this should not be set
   name: ""
   # revision declares which revision this gateway is a part of
@@ -29,13 +31,13 @@ defaults:
     prometheus.io/scrape: "true"
     prometheus.io/path: "/stats/prometheus"
     inject.istio.io/templates: "gateway"
-    sidecar.istio.io/inject: "false"
+    sidecar.istio.io/inject: "true"
 
   # Define the security context for the pod.
   # If unset, this will be automatically set to the minimum privileges required to bind to port 80 and 443.
   # On Kubernetes 1.22+, this only requires the `net.ipv4.ip_unprivileged_port_start` sysctl.
-  securityContext: ~
-  containerSecurityContext: ~
+  securityContext: {}
+  containerSecurityContext: {}
 
   service:
     # Type of service. Set to "None" to disable the service entirely
@@ -53,35 +55,27 @@ defaults:
       port: 443
       protocol: TCP
       targetPort: 443
-    - name: tcp
-      port: 31400
-      protocol: TCP
-      targetPort: 31400
-    - name: tls
-      port: 15443
-      protocol: TCP
-      targetPort: 15443
-    selector:
-      app: istio-ingress
-      istio: ingressgateway
     annotations: {}
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
-    #IMPORTANT - see externalTrafficPolicy in docs
+    # Set policy to local to respect IP passed by AWS ELB, and not route directly to nodes.
+    # https://istio.io/latest/docs/tasks/security/authorization/authz-ingress/#network
     externalTrafficPolicy: "Local"
     externalIPs: []
     ipFamilyPolicy: ""
     ipFamilies: []
     ## Whether to automatically allocate NodePorts (only for LoadBalancers).
     # allocateLoadBalancerNodePorts: false
+    ## Set LoadBalancer class (only for LoadBalancers).
+    # loadBalancerClass: ""
 
   resources:
     requests:
       cpu: 100m
       memory: 128Mi
     limits:
-      cpu: 500m
-      memory: 512Mi
+      cpu: 2000m
+      memory: 1024Mi
 
   autoscaling:
     enabled: true
@@ -94,8 +88,21 @@ defaults:
   # Pod environment variables
   env: {}
 
+  # Deployment Update strategy
+  strategy: {}
+  
+  # Sets the Deployment minReadySeconds value
+  minReadySeconds:
+  
+  # Optionally configure a custom readinessProbe. By default the control plane
+  # automatically injects the readinessProbe. If you wish to override that
+  # behavior, you may define your own readinessProbe here.
+  readinessProbe: {}
+
   # Labels to apply to all resources
-  labels: {}
+  labels:
+    # By default, don't enroll gateways into the ambient dataplane
+    "istio.io/dataplane-mode": none
 
   # Annotations to apply to all resources
   annotations: {}
@@ -147,6 +154,7 @@ defaults:
   #
   podDisruptionBudget: {}
 
+  # Sets the per-pod terminationGracePeriodSeconds setting.
   terminationGracePeriodSeconds: 30
 
   # A list of `Volumes` added into the Gateway Pods. See

--- a/helm-values/istiod.yaml
+++ b/helm-values/istiod.yaml
@@ -20,8 +20,11 @@ _internal_defaults_do_not_set:
   # Resources for a small pilot install
   resources:
     requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
       cpu: 500m
-      memory: 2048Mi
+      memory: 1024Mi
 
   # Set to `type: RuntimeDefault` to use the default profile if available.
   seccompProfile: {}
@@ -236,10 +239,10 @@ _internal_defaults_do_not_set:
     defaultResources:
       requests:
         cpu: 10m
-      #   memory: 128Mi
-      # limits:
-      #   cpu: 100m
-      #   memory: 128Mi
+        memory: 128Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
 
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
@@ -370,11 +373,11 @@ _internal_defaults_do_not_set:
       # Resources for the sidecar.
       resources:
         requests:
-          cpu: 100m
-          memory: 128Mi
+          cpu: 10m
+          memory: 50Mi
         limits:
-          cpu: 2000m
-          memory: 1024Mi
+          cpu: 200m
+          memory: 128Mi
 
       # Default port for Pilot agent health checks. A value of 0 will disable health checking.
       statusPort: 15020

--- a/helm-values/istiod.yaml
+++ b/helm-values/istiod.yaml
@@ -1,108 +1,113 @@
-defaults:
-  #.Values.pilot for discovery and mesh wide config
+# "_internal_defaults_do_not_set" is a workaround for Helm limitations. Users should NOT set "._internal_defaults_do_not_set" explicitly, but rather directly set the fields internally.
+# For instance, instead of `--set _internal_defaults_do_not_set.foo=bar``, just set `--set foo=bar`.
+_internal_defaults_do_not_set:
+  autoscaleEnabled: true
+  autoscaleMin: 1
+  autoscaleMax: 5
+  autoscaleBehavior: {}
+  replicaCount: 1
+  rollingMaxSurge: 100%
+  rollingMaxUnavailable: 25%
 
-  ## Discovery Settings
-  pilot:
-    autoscaleEnabled: true
-    autoscaleMin: 1
-    autoscaleMax: 5
-    autoscaleBehavior: {}
-    replicaCount: 1
-    rollingMaxSurge: 100%
-    rollingMaxUnavailable: 25%
+  hub: ""
+  tag: ""
+  variant: ""
 
-    hub: ""
-    tag: ""
-    variant: ""
+  # Can be a full hub/image:tag
+  image: pilot
+  traceSampling: 1.0
 
-    # Can be a full hub/image:tag
-    image: pilot
-    traceSampling: 1.0
+  # Resources for a small pilot install
+  resources:
+    requests:
+      cpu: 500m
+      memory: 2048Mi
 
-    # Resources for a small pilot install
-    resources:
-      requests:
-        cpu: 100m
-        memory: 256Mi
-      limits:
-        cpu: 200m
-        memory: 512Mi
+  # Set to `type: RuntimeDefault` to use the default profile if available.
+  seccompProfile: {}
 
-    # Set to `type: RuntimeDefault` to use the default profile if available.
-    seccompProfile: {}
+  # Whether to use an existing CNI installation
+  cni:
+    enabled: false
+    provider: default
 
-    # Whether to use an existing CNI installation
-    cni:
-      enabled: false
-      provider: default
+  # Additional container arguments
+  extraContainerArgs: []
 
-    # Additional container arguments
-    extraContainerArgs: []
+  env: {}
 
-    env: {}
-    
-    # Settings related to the untaint controller
-    # This controller will remove `cni.istio.io/not-ready` from nodes when the istio-cni pod becomes ready
-    # It should be noted that cluster operator/owner is responsible for having the taint set by their infrastructure provider when new nodes are added to the cluster; the untaint controller does not taint nodes
-    taint:
-      # Controls whether or not the untaint controller is active
-      enabled: false
-      # What namespace the untaint controller should watch for istio-cni pods. This is only required when istio-cni is running in a different namespace than istiod
-      namespace: ""
+  envVarFrom: []
 
-    affinity: {}
+  # Settings related to the untaint controller
+  # This controller will remove `cni.istio.io/not-ready` from nodes when the istio-cni pod becomes ready
+  # It should be noted that cluster operator/owner is responsible for having the taint set by their infrastructure provider when new nodes are added to the cluster; the untaint controller does not taint nodes
+  taint:
+    # Controls whether or not the untaint controller is active
+    enabled: false
+    # What namespace the untaint controller should watch for istio-cni pods. This is only required when istio-cni is running in a different namespace than istiod
+    namespace: ""
 
-    tolerations: []
+  affinity: {}
 
-    cpu:
-      targetAverageUtilization: 80
-    memory: {}
-      # targetAverageUtilization: 80
+  tolerations: []
 
-    # Additional volumeMounts to the istiod container
-    volumeMounts: []
+  cpu:
+    targetAverageUtilization: 80
+  memory: {}
+    # targetAverageUtilization: 80
 
-    # Additional volumes to the istiod pod
-    volumes: []
+  # Additional volumeMounts to the istiod container
+  volumeMounts: []
 
-    nodeSelector: {}
-    podAnnotations: {}
-    serviceAnnotations: {}
-    serviceAccountAnnotations: {}
+  # Additional volumes to the istiod pod
+  volumes: []
 
-    topologySpreadConstraints: []
+  # Inject initContainers into the istiod pod
+  initContainers: []
 
-    # You can use jwksResolverExtraRootCA to provide a root certificate
-    # in PEM format. This will then be trusted by pilot when resolving
-    # JWKS URIs.
-    jwksResolverExtraRootCA: ""
+  nodeSelector: {}
+  podAnnotations: {}
+  serviceAnnotations: {}
+  serviceAccountAnnotations: {}
+  sidecarInjectorWebhookAnnotations: {}
 
-    # This is used to set the source of configuration for
-    # the associated address in configSource, if nothing is specified
-    # the default MCP is assumed.
-    configSource:
-      subscribedResources: []
+  topologySpreadConstraints: []
 
-    # The following is used to limit how long a sidecar can be connected
-    # to a pilot. It balances out load across pilot instances at the cost of
-    # increasing system churn.
-    keepaliveMaxServerConnectionAge: 30m
+  # You can use jwksResolverExtraRootCA to provide a root certificate
+  # in PEM format. This will then be trusted by pilot when resolving
+  # JWKS URIs.
+  jwksResolverExtraRootCA: ""
 
-    # Additional labels to apply to the deployment.
-    deploymentLabels: {}
+  # The following is used to limit how long a sidecar can be connected
+  # to a pilot. It balances out load across pilot instances at the cost of
+  # increasing system churn.
+  keepaliveMaxServerConnectionAge: 30m
 
-    ## Mesh config settings
+  # Additional labels to apply to the deployment.
+  deploymentLabels: {}
 
-    # Install the mesh config map, generated from values.yaml.
-    # If false, pilot wil use default values (by default) or user-supplied values.
-    configMap: true
+  ## Mesh config settings
 
-    # Additional labels to apply on the pod level for monitoring and logging configuration.
-    podLabels: {}
+  # Install the mesh config map, generated from values.yaml.
+  # If false, pilot wil use default values (by default) or user-supplied values.
+  configMap: true
 
-    # Setup how istiod Service is configured. See https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services
-    ipFamilyPolicy: ""
-    ipFamilies: []
+  # Additional labels to apply on the pod level for monitoring and logging configuration.
+  podLabels: {}
+
+  # Setup how istiod Service is configured. See https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services
+  ipFamilyPolicy: ""
+  ipFamilies: []
+
+  # Ambient mode only.
+  # Set this if you install ztunnel to a different namespace from `istiod`.
+  # If set, `istiod` will allow connections from trusted node proxy ztunnels
+  # in the provided namespace.
+  # If unset, `istiod` will assume the trusted node proxy ztunnel resides
+  # in the same namespace as itself.
+  trustedZtunnelNamespace: ""
+  # Set this if you install ztunnel with a name different from the default.
+  trustedZtunnelName: ""
 
   sidecarInjectorWebhook:
     # You can use the field called alwaysInjectSelector and neverInjectSelector which will always inject the sidecar or
@@ -165,6 +170,10 @@ defaults:
     # defaultTemplates: ["sidecar", "hello"]
     defaultTemplates: []
   istiodRemote:
+    # If `true`, indicates that this cluster/install should consume a "remote istiod" installation,
+    # and istiod itself will NOT be installed in this cluster - only the support resources necessary
+    # to utilize a remote instance.
+    enabled: false
     # Sidecar injector mutating webhook configuration clientConfig.url value.
     # For example: https://$remotePilotAddress:15017/inject
     # The host should not refer to a service running in the cluster; use a service reference by specifying
@@ -227,17 +236,17 @@ defaults:
     defaultResources:
       requests:
         cpu: 10m
-        memory: 128Mi
-      limits:
-        cpu: 100m
-        memory: 128Mi
+      #   memory: 128Mi
+      # limits:
+      #   cpu: 100m
+      #   memory: 128Mi
 
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
     hub: docker.io/istio
     # Default tag for Istio images.
-    tag: 1.22.1
+    tag: 1.26.0
     # Variant of the image to use.
     # Currently supported are: [debug, distroless]
     variant: ""
@@ -309,9 +318,6 @@ defaults:
       # not set, then the global "logLevel" will be used.
       componentLogLevel: "misc:error"
 
-      # If set, newly injected sidecars will have core dumps enabled.
-      enableCoreDump: false
-
       # istio ingress capture allowlist
       # examples:
       #     Redirect only selected ports:            --includeInboundPorts="80,8080"
@@ -331,6 +337,10 @@ defaults:
       # Log level for proxy, applies to gateways and sidecars.
       # Expected values are: trace|debug|info|warning|error|critical|off
       logLevel: warning
+
+      # Specify the path to the outlier event log.
+      # Example: /dev/stdout
+      outlierLogPath: ""
 
       #If set to true, istio-proxy container will have privileged securityContext
       privileged: false
@@ -360,22 +370,25 @@ defaults:
       # Resources for the sidecar.
       resources:
         requests:
-          cpu: 10m
-          memory: 50Mi
-        limits:
-          cpu: 200m
+          cpu: 100m
           memory: 128Mi
+        limits:
+          cpu: 2000m
+          memory: 1024Mi
 
       # Default port for Pilot agent health checks. A value of 0 will disable health checking.
       statusPort: 15020
 
       # Specify which tracer to use. One of: zipkin, lightstep, datadog, stackdriver, none.
       # If using stackdriver tracer outside GCP, set env GOOGLE_APPLICATION_CREDENTIALS to the GCP credential file.
-      tracer: "zipkin"
+      tracer: "none"
 
     proxy_init:
       # Base name for the proxy_init container, used to configure iptables.
       image: proxyv2
+      # Bypasses iptables idempotency handling, and attempts to apply iptables rules regardless of table state, which may cause unrecoverable failures.
+      # Do not use unless you need to work around an issue of the idempotency handling. This flag will be removed in future releases.
+      forceApplyIptables: false
 
     # configure remote pilot and istiod service and endpoint
     remotePilotAddress: ""
@@ -390,9 +403,7 @@ defaults:
     # If not set explicitly, default to the Istio discovery address.
     caAddress: ""
 
-    # Configure a remote cluster data plane controlled by an external istiod.
-    # When set to true, istiod is not deployed locally and only a subset of the other
-    # discovery charts are enabled.
+    # Enable control of remote clusters.
     externalIstiod: false
 
     # Configure a remote cluster as the config cluster for an external istiod.
@@ -495,13 +506,49 @@ defaults:
     # mechanisms (e.g., environmental variable CA_PROVIDER).
     caName: ""
 
-    # whether to use autoscaling/v2 template for HPA settings
-    # for internal usage only, not to be configured by users.
-    autoscalingv2API: true
+    waypoint:
+      # Resources for the waypoint proxy.
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: "2"
+          memory: 1Gi
+
+      # If specified, affinity defines the scheduling constraints of waypoint pods.
+      affinity: {}
+
+      # Topology Spread Constraints for the waypoint proxy.
+      topologySpreadConstraints: []
+
+      # Node labels for the waypoint proxy.
+      nodeSelector: {}
+
+      # Tolerations for the waypoint proxy.
+      tolerations: []
 
   base:
     # For istioctl usage to disable istio config crds in base
     enableIstioConfigCRDs: true
 
+  # Gateway Settings
+  gateways:
+    # Define the security context for the pod.
+    # If unset, this will be automatically set to the minimum privileges required to bind to port 80 and 443.
+    # On Kubernetes 1.22+, this only requires the `net.ipv4.ip_unprivileged_port_start` sysctl.
+    securityContext: {}
 
+    # Set to `type: RuntimeDefault` to use the default profile for templated gateways, if your container runtime supports it
+    seccompProfile: {}
+
+  # gatewayClasses allows customizing the configuration of the default deployment of Gateways per GatewayClass.
+  # For example:
+  # gatewayClasses:
+  #   istio:
+  #     service:
+  #       spec:
+  #         type: ClusterIP
+  # Per-Gateway configuration can also be set in the `Gateway.spec.infrastructure.parametersRef` field.
+  gatewayClasses: {}
 

--- a/helm-values/kiali-operator.yaml
+++ b/helm-values/kiali-operator.yaml
@@ -3,12 +3,13 @@ fullnameOverride: ""
 
 image: # see: https://quay.io/repository/kiali/kiali-operator?tab=tags
   repo: quay.io/kiali/kiali-operator # quay.io/kiali/kiali-operator
-  tag: v1.88.0 # version string like v1.39.0 or a digest hash
+  tag: v2.10.0 # version string like v1.39.0 or a digest hash
   digest: "" # use "sha256" if tag is a sha256 hash (do NOT prefix this value with a "@")
   pullPolicy: Always
   pullSecrets: []
 
 # Deployment options for the operator pod.
+extraLabels: {}
 nodeSelector: {}
 podAnnotations: {}
 podLabels: {}
@@ -39,19 +40,10 @@ debug:
 watchNamespace: ""
 
 # Set to true if you want the operator to be able to create cluster roles. This is necessary
-# if you want to support Kiali CRs with spec.deployment.accessible_namespaces of '**'.
+# if you want to support Kiali CRs with spec.deployment.cluster_wide_access=true.
 # Setting this to "true" requires allowAllAccessibleNamespaces to be "true" also.
-# Note that this will be overriden to "true" if cr.create is true and cr.spec.deployment.accessible_namespaces is ['**'].
+# Note that this will be overriden to "true" if cr.create is true and cr.spec.deployment.cluster_wide_access=true.
 clusterRoleCreator: true
-
-# Set to a list of secrets in the cluster that the operator will be allowed to read. This is necessary if you want to
-# support Kiali CRs with spec.kiali_feature_flags.certificates_information_indicators.enabled=true.
-# The secrets in this list will be the only ones allowed to be specified in any Kiali CR (in the setting
-# spec.kiali_feature_flags.certificates_information_indicators.secrets).
-# If you set this to an empty list, the operator will not be given permission to read any additional secrets
-# found in the cluster, and thus will only support a value of "false" in the Kiali CR setting
-# spec.kiali_feature_flags.certificates_information_indicators.enabled.
-secretReader: ['cacerts', 'istio-ca-secret']
 
 # Set to true if you want to allow the operator to only be able to install Kiali in view-only-mode.
 # The purpose for this setting is to allow you to restrict the permissions given to the operator itself.
@@ -83,21 +75,11 @@ allowAdHocOSSMConsoleImage: false
 allowSecurityContextOverride: false
 
 # allowAllAccessibleNamespaces tells the operator to allow a user to be able to configure Kiali
-# to access all namespaces in the cluster via spec.deployment.accessible_namespaces=['**'].
-# If this is false, the user must specify an explicit list of namespaces in the Kiali CR.
+# to access all namespaces in the cluster via spec.deployment.cluster_wide_access=true.
+# If this is false, the user must specify an explicit set of namespaces in the Kiali CR via spec.deployment.discovery_selectors.
 # Setting this to "true" requires clusterRoleCreator to be "true" also.
-# Note that this will be overriden to "true" if cr.create is true and cr.spec.deployment.accessible_namespaces is ['**'].
+# Note that this will be overriden to "true" if cr.create is true and cr.spec.deployment.cluster_wide_access=true.
 allowAllAccessibleNamespaces: true
-
-# accessibleNamespacesLabel restricts the namespaces that a user can add to the Kiali CR spec.deployment.accessible_namespaces.
-# This value is either an empty string (which disables this feature) or a label name with an optional label value
-# (e.g. "mylabel" or "mylabel=myvalue"). Only namespaces that have that label will be permitted in
-# spec.deployment.accessible_namespaces. Any namespace not labeled properly but specified in accessible_namespaces will cause
-# the operator to abort the Kiali installation.
-# If just a label name (but no label value) is specified, the label value the operator will look for is the value of
-# the Kiali CR's spec.istio_namespace. In other words, the operator will look for the named label whose value must be the name
-# of the Istio control plane namespace (which is typically, but not necessarily, "istio-system").
-accessibleNamespacesLabel: ""
 
 # watchesFile: If specified, this determines what watches file will be used to configure the operator. There are four different
 # files that can be selected: (a) `watches-os.yaml`, (b) `watches-os-ns.yaml`, (c) `watches-k8s.yaml` or (d) `watches-k8s-ns.yaml`.
@@ -107,8 +89,7 @@ accessibleNamespacesLabel: ""
 # the default behavior and is not necessary if your Kiali CRs will have `spec.deployment.cluster_wide_access` set to `true`.
 watchesFile: ""
 
-# For what a Kiali CR spec can look like, see:
-# https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml
+# For what a Kiali CR spec can look like, see: https://kiali.io/docs/configuration/kialis.kiali.io/
 cr:
   create: true
   name: kiali
@@ -119,12 +100,10 @@ cr:
 
   # Annotations to place in the Kiali CR metadata.
   annotations: {}
-
   spec:
     istio_namespace: istio-system
     deployment:
-      accessible_namespaces:
-      - '**'
+      cluster_wide_access: true
     auth:
       strategy: anonymous
     server:
@@ -163,16 +142,3 @@ cr:
         - name: "Istio Wasm Extension Dashboard"
       prometheus:
         url: http://prometheus-server:80
-      tracing:
-        # Enabled by default. Kiali will anyway fallback to disabled if
-        # Jaeger is unreachable.
-        enabled: true
-        # Make sure the URL you provide corresponds to the non-GRPC enabled endpoint
-        # if you set "use_grpc" to false.
-        in_cluster_url: "http://jaeger-allinone-query.istio-system:16685/"
-        use_grpc: true
-        # Public facing URL of Jaeger
-        url: "/jaeger"
-
-
-

--- a/variables.tf
+++ b/variables.tf
@@ -42,7 +42,7 @@ variable "r53_subdomain_zone_id_aux" {
 variable "istio_chart_version" {
   description = "Helm chart version"
   type        = string
-  default     = "1.22.1"
+  default     = "1.26.0"
 }
 
 variable "istio_namespace" {

--- a/variables.tf
+++ b/variables.tf
@@ -82,7 +82,7 @@ variable "prometheus_version" {
 
 variable "kiali_operator_chart_version" {
   description = "Version of kiali operator chart to deploy."
-  default     = "1.88.0"
+  default     = "2.10.0"
 }
 
 variable "aws_region" {}


### PR DESCRIPTION
- Rev kialli 1.88.x to 2.10.x
- rev istio 1.22.x to 1.26.x


requires 1 time manual migration prep on cluster to label CRDs.

```
do
   kubectl label "$crd" "app.kubernetes.io/managed-by=Helm"
   kubectl annotate "$crd" "meta.helm.sh/release-name=istio-base" # replace with actual Helm release name, if different from the documentation default
   kubectl annotate "$crd" "meta.helm.sh/release-namespace=istio-system" # replace with actual istio namespace
done
```